### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/tutorials/Particles.md
+++ b/docs/tutorials/Particles.md
@@ -6,7 +6,7 @@ Most of the article assumes you know to avoid calling the player in init.
 ```lua
 particles:newParticle(particleID,position,velocity)
 ```
-If you're looking on the [Minecraft wiki](https://minecraft.fandom.com/wiki/Particles) then the particle id is the name under the 'Java Edition ID Name' column. Or, it's the same id used by the /particle command. If you're using Minecraft particles you can exclude the Minecraft "mod name".
+If you're looking on the [Minecraft wiki](https://minecraft.wiki/w/Particles) then the particle id is the name under the 'Java Edition ID Name' column. Or, it's the same id used by the /particle command. If you're using Minecraft particles you can exclude the Minecraft "mod name".
 ```lua
 particles:newParticle("minecraft:explosion",player:getPos())
 ```

--- a/docs/tutorials/Sounds.md
+++ b/docs/tutorials/Sounds.md
@@ -9,7 +9,7 @@ sounds:playSound(soundID,position,volume,pitch,loop)
 ```
 As you can see this function takes five arguments, the sound ID, the position it will be played, the volume (this dictates how close players need to be to hear the sound, default is 1), its pitch (default is 1), and whether or not it will start playing immediately after it ends (default is false).
 
-For Minecraft sounds the sound ID is the internal name of the sound, you can find these on the [Minecraft Wiki](https://minecraft.fandom.com/wiki/Sounds.json/Java_Edition_values) under the Sound Event column. It will play one of the sounds associated with that ID at random.
+For Minecraft sounds the sound ID is the internal name of the sound, you can find these on the [Minecraft Wiki](https://minecraft.wiki/w/Sounds.json/Java_Edition_values) under the Sound Event column. It will play one of the sounds associated with that ID at random.
 
 Example, note that the id is a string because it's in quotes:
 ```lua


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki