### PR TITLE
fix pages deploy/preview workflows

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Deploy Preview
         uses: rossjrw/pr-preview-action@v1.4.4
         with:
+          token: ${{ secrets.PAGES_DEPLOY_TOKEN }}
           source-dir: ./build/
 
   cleanup:
@@ -46,5 +47,6 @@ jobs:
       - name: Cleanup Preview
         uses: rossjrw/pr-preview-action@v1.4.4
         with:
+          token: ${{ secrets.PAGES_DEPLOY_TOKEN }}
           source-dir: ./build/
           action: remove

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
+          token: ${{ secrets.PAGES_DEPLOY_TOKEN }}
           force: false
           folder: ./build/
           branch: gh-pages


### PR DESCRIPTION
makes it so they use provided token instead of repository scoped one