### PR TITLE
fix file trees + add highlighting

### DIFF
--- a/docs/enums/ItemDisplayModes.md
+++ b/docs/enums/ItemDisplayModes.md
@@ -39,7 +39,7 @@ models:newItem('CarrotTask')
 
 ```lua
 function events.item_render(item, mode, pos, rot, scale, lefty)
--- highlight-next-line
+    -- highlight-next-line
     if mode == "HEAD" then
         return models.myModel.Item
     end

--- a/docs/enums/PlayStates.md
+++ b/docs/enums/PlayStates.md
@@ -4,7 +4,7 @@ The play state of a Blockbench animation, detected with <code>getPlayState()</co
 
 ```lua
 function events.tick()
--- highlight-next-line
+    -- highlight-next-line
     local isDancing = animations.myModel.dance:getPlayState() == "PLAYING"
     models.myModel.discoBall:setVisible(isDancing)
 end

--- a/docs/enums/RenderModes.md
+++ b/docs/enums/RenderModes.md
@@ -3,8 +3,8 @@ Render modes indicate what context the avatar is being rendered in.
 **Example**:
 
 ```lua
-function events.render(_,context)
--- highlight-next-line
+function events.render(_, context)
+    -- highlight-next-line
     models.myModel.World:setVisible(context ~= "FIRST_PERSON")
 end
 ```

--- a/docs/enums/UseActions.md
+++ b/docs/enums/UseActions.md
@@ -4,7 +4,7 @@ What hold-right-click action an item you're using has. As this is for holding ac
 
 ```lua
 function events.tick()
--- highlight-next-line
+    -- highlight-next-line
     local isEating = player:getActiveItem():getUseAction() == "EAT"
     animations.myModel.eat:setPlaying(isEating)
 end

--- a/docs/globals/Models/SpriteTask.md
+++ b/docs/globals/Models/SpriteTask.md
@@ -63,7 +63,7 @@ Sets the texture dimensions, used in UV calculation. Accepts a `Vector2` of dime
 
 ```lua
 -- use the long water_flow texture then make it one block
-mySprite:setTexture('textures/block/water_flow.png', 16, 16)
+mySprite:setTexture("textures/block/water_flow.png", 16, 16)
 -- highlight-next-line
 mySprite:setDimensions(32, 1024)
 ```
@@ -140,15 +140,15 @@ Sets this texture UV offset. Accepts a `Vector2` of UV values or a number per va
 
 ```lua
 -- Let's make a sprite task of flowing water!
-mySprite:setTexture('textures/block/water_flow.png', 16, 16)
+mySprite:setTexture("textures/block/water_flow.png", 16, 16)
 mySprite:setDimensions(32, 1024)
 mySprite:setColor(world.getBiome():getWaterColor())
 
 local t = 0
 
 function events.tick()
--- highlight-next-line
-    mySprite:setUV(1, t/32)
+    -- highlight-next-line
+    mySprite:setUV(1, t / 32)
     t = t + 1
 end
 ```
@@ -175,14 +175,14 @@ Set this texture UV offset, in pixels, based on the texture's dimension. Accepts
 
 ```lua
 -- Let's make a sprite task of flowing water!
-mySprite:setTexture('textures/block/water_flow.png', 16, 16)
+mySprite:setTexture("textures/block/water_flow.png", 16, 16)
 mySprite:setDimensions(32, 1024)
 mySprite:setColor(world.getBiome():getWaterColor())
 
 local t = 0
 
 function events.tick()
--- highlight-next-line
+    -- highlight-next-line
     mySprite:setUVPixels(1, t)
     t = t - 1
 end

--- a/src/components/FileTree/Node.tsx
+++ b/src/components/FileTree/Node.tsx
@@ -4,6 +4,7 @@ import { FC } from "react";
 export type FileTreeNodeProps = PropsWithChildren<{
   icon?: string | undefined;
   label: string | React.ReactNode;
+  highlight?: boolean | undefined;
 }>;
 
 const FileTreeNode: FC = () => {

--- a/src/components/FileTree/Root.tsx
+++ b/src/components/FileTree/Root.tsx
@@ -16,6 +16,7 @@ const resolveFileTree = (children: React.ReactNode): Node[] => {
       return {
         icon: nodeProps.icon,
         label: nodeProps.label,
+        highlight: nodeProps.highlight,
         children: nodeProps.children ? resolveFileTree(nodeProps.children) : [],
       };
     } else {
@@ -63,6 +64,7 @@ const flattenFileTree = (tree: Node[], depth = 0) => {
     flattened.push({
       label: node.label,
       icon: node.icon,
+      highlight: node.highlight,
       depth,
       end: index === tree.length - 1,
     });
@@ -136,12 +138,18 @@ const FileTreeRoot: FC<PropsWithChildren> = ({ children }) => {
   return (
     <pre>
       {flattenedTree.map((node, index) => {
+        console.log(node);
+
         return (
-          <div key={index} style={{ display: "flex", alignItems: "center" }}>
-            <div style={{ marginRight: "-0.15rem" }}>{node.start}</div>
+          <span
+            key={index}
+            style={{ display: "flex", alignItems: "center" }}
+            className={node.highlight ? "code-block-highlighted-line" : ""}
+          >
+            <span style={{ marginRight: "-0.15rem" }}>{node.start}</span>
             <Emoji icon={node.icon ?? "file/folder"} />
-            <div style={{ marginLeft: "0.25rem" }}>{node.label}</div>
-          </div>
+            <span style={{ marginLeft: "0.25rem" }}>{node.label}</span>
+          </span>
         );
       })}
     </pre>

--- a/src/components/FileTree/Root.tsx
+++ b/src/components/FileTree/Root.tsx
@@ -10,7 +10,7 @@ const resolveFileTree = (children: React.ReactNode): Node[] => {
   const resolved = React.Children.map(children, (child): Node | null => {
     if (!React.isValidElement(child)) return null;
 
-    if (child.props.originalType === FileTreeNode) {
+    if (child.type === FileTreeNode) {
       const nodeProps = child.props as unknown as FileTreeNodeProps;
 
       return {
@@ -42,12 +42,12 @@ const transposeJoiners = (matrix: Joiner[][]): Joiner[][] => {
   const rows = matrix.length;
   if (rows === 0) return matrix;
 
-  const cols = matrix[0].length;
+  const cols = matrix[0]!.length;
   const result: Joiner[][] = Array.from({ length: cols }, () => []);
 
   for (let i = 0; i < rows; i++) {
     for (let j = 0; j < cols; j++) {
-      result[j][i] = matrix[i][j];
+      result[j]![i] = matrix[i]![j]!;
     }
   }
 

--- a/src/components/FileTree/Root.tsx
+++ b/src/components/FileTree/Root.tsx
@@ -138,8 +138,6 @@ const FileTreeRoot: FC<PropsWithChildren> = ({ children }) => {
   return (
     <pre>
       {flattenedTree.map((node, index) => {
-        console.log(node);
-
         return (
           <span
             key={index}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -29,23 +29,29 @@
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.1);
 }
 
-.code-block-highlighted-line {
-  background-color: #00000010;
+.code-block-highlighted-line,
+.code-block-error-line {
+  --highlight-border-width: 3px;
+
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
-  padding: 0 var(--ifm-pre-padding);
-  border-left: 3px solid #00000080;
+  padding-right: 0 var(--ifm-pre-padding);
+  padding-left: calc(var(--ifm-pre-padding) - var(--highlight-border-width));
+  border-left-width: var(--highlight-border-width);
+  border-left-style: solid;
+}
+
+.code-block-highlighted-line {
+  background-color: #00000010;
+  border-left-color: #00000080;
 }
 
 [data-theme='dark'] .code-block-highlighted-line {
   background-color: #ffffff10;
-  border-left: 3px solid #ffffff80;
+  border-left-color: #ffffff80;
 }
 
 .code-block-error-line {
   background-color: #ff000020;
-  display: block;
-  margin: 0 calc(-1 * var(--ifm-pre-padding));
-  padding: 0 var(--ifm-pre-padding);
-  border-left: 3px solid #ff000080;
+  border-left-color: #ff000080;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,7 +35,7 @@
 
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
-  padding-right: 0 var(--ifm-pre-padding);
+  padding-right: var(--ifm-pre-padding);
   padding-left: calc(var(--ifm-pre-padding) - var(--highlight-border-width));
   border-left-width: var(--highlight-border-width);
   border-left-style: solid;


### PR DESCRIPTION
fix file trees not being resolved correctly after upgrade to react 18

also adds highlighting
example:
![image](https://github.com/FiguraMC/wiki/assets/41586666/b030880b-022d-43de-85b5-f53bd31b2aff)
```tsx
<FileTreeRoot>
  <FileTreeNode label="subfolderA" icon="file/folder">
    <FileTreeNode label="Pet.bbmodel" icon="file/bbmodel" highlight/>
    <FileTreeNode label="bow.bbmodel" icon="file/bbmodel"/>
  </FileTreeNode>
  <FileTreeNode label="subfolderB" icon="file/folder">
    <FileTreeNode label="model.bbmodel" icon="file/bbmodel"/>
    <FileTreeNode label="bow.bbmodel" icon="file/bbmodel"/>
  </FileTreeNode>
</FileTreeRoot>
```

