### PR TITLE
fix syntax error in events.damage description

### DIFF
--- a/docs/globals/Events/Events.md
+++ b/docs/globals/Events/Events.md
@@ -258,7 +258,7 @@ The last three arguments may return nil if there is no direct damage source
 
 ```lua
 function events.damage(type, source, attacker, pos)
-    log("Damaged from " .. type .. ")
+    log("Damaged from " .. type)
     if attacker then
         log("by a " .. attacker:getType())
     end


### PR DESCRIPTION
my name is riftlight and despite thoroughly vetting my 4 line PR i made it with a syntax error